### PR TITLE
Improve the popup

### DIFF
--- a/dunedynasty-launcher
+++ b/dunedynasty-launcher
@@ -2,10 +2,10 @@
 /bin/cp -r /app/share/dunedynasty $XDG_DATA_HOME
 if ! [ -f "$XDG_DATA_HOME/dunedynasty/data/DUNE.PAK" ]; then
   error="ERROR: Dune II data files not found.\nPlace your Dune2 1.07eu data files in $XDG_DATA_HOME/dunedynasty/data"
-  if command -v notify-send >/dev/null 2>&1; then
-    notify-send "Dune Dynasty" "$error"
-  elif command -v zenity >/dev/null 2>&1; then
+  if command -v zenity >/dev/null 2>&1; then
     zenity --error --title="Dune Dynasty" --text="$error"
+  elif command -v notify-send >/dev/null 2>&1; then
+    notify-send "Dune Dynasty" "$error"
   else
     echo $error
   fi

--- a/io.github.gameflorist.dunedynasty.desktop
+++ b/io.github.gameflorist.dunedynasty.desktop
@@ -2,8 +2,7 @@
 Version=1.0
 Type=Application
 Comment=A remaster / enhancement of the classic real-time strategy game Dune II by Westwood Studios
-Exec=dunedynasty
+Exec=dunedynasty-launcher
 Icon=io.github.gameflorist.dunedynasty
 Name=Dune Dynasty
 Categories=Game;
-Terminal=false

--- a/io.github.gameflorist.dunedynasty.yaml
+++ b/io.github.gameflorist.dunedynasty.yaml
@@ -1,6 +1,6 @@
 app-id: io.github.gameflorist.dunedynasty
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 command: dunedynasty-launcher
 finish-args:


### PR DESCRIPTION
- Update the runtime to a newer version that has libnotify already integrated in it
- Change the priority of the tool used to notify, to use the popup by default
- Change the destktop file to use the launcher script

This is how it's show with zenity in my gnome in steamdeck:
![image](https://github.com/user-attachments/assets/5e62c2ae-50b9-4914-9944-03b08ced6478)

And this is what shows when the notify-send is executed (Not exactly, but you can get an idea):
![image](https://github.com/user-attachments/assets/ef11855c-9a9e-43c5-b937-cc78072e9baa)

